### PR TITLE
DCV-1198 DCV-1052 ignore dbt warnings output when errorcode !=0:

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Contributions are welcome! Just submit a Pull Request or Github Issue.
 docker build -t dag-factory .
 
 ## --network main_network refers to dag-factory (Airflow) needs to be ran in the same Docker Network as Airbyte
-docker run -d -p "8080:8080" -v "$(pwd):/app" --network main_network dag-factory
+docker run -d -p "8080:8080" -v "$(pwd):/app" --network airbyte_default dag-factory
 ```
 
 Navigate to https://localhost:8080 and login using credentials admin/admin.


### PR DESCRIPTION
- Ignoring dbt warnings is done obtaining from 'dbt ls' only the stdout starting with 'source:' (this excludes possible warning messages)
- Messages of dbt errorcode != 0 are constructed both analyzing stderr and stdout (certain dbt errors, like those from 'dbt deps', count as stdout instead of stderr). This is why error_message contains both stderr and stdout if they exist.
- README's 'docker run' now uses 'airbyte_default' network: we no longer need 'docker network create', Airbyte now implements it by default